### PR TITLE
Built-in sort implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "homepage": "https://github.com/jwhitfieldseed/prequel#readme",
   "dependencies": {
-    "lodash.sortbyorder": "^3.4.4"
   },
   "devDependencies": {
     "babel-cli": "^6.2.0",

--- a/src/util.js
+++ b/src/util.js
@@ -58,6 +58,12 @@ export function result(expr) {
 }
 
 export function sortByOrder(input, orders) {
+  if (!orders || orders.length === 0) {
+    return input;
+  }
+  
+  const index = Symbol("index");
+
   function comparator(a, b) {
     for (const [field, dir] of orders) {
       const compared = compareValues(a[field], b[field]);
@@ -68,16 +74,26 @@ export function sortByOrder(input, orders) {
       }
     }
 
-    return 0;
+    return compareOrdinals(a[index], b[index]);
   }
 
-  return [...input].sort(comparator);
+  // Hack - add index to each input row to mimic stable [].sort
+  return input
+    // .map((row, i) => {
+    //   row[index] = i;
+    //   return row;
+    // })
+    .sort(comparator);
 }
 
 function compareValues (a, b) {
-  if (isFunction(a.localeCompare)) {
-    return a.localeCompare("" + b);
-  } else if (a < b) {
+  return (isFunction(a.localeCompare))
+    ? a.localeCompare(b)
+    : compareOrdinals(a, b);
+}
+
+function compareOrdinals(a, b) {
+  if (a < b) {
     return -1;
   } else if (a > b) {
     return 1;

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,5 @@
+const DESC = "desc";
+
 function reduceToObject(inputArray, getKey, getValue) {
   const keyFunc = isFunction(getKey) ? getKey : obj => obj[getKey];
 
@@ -62,7 +64,19 @@ export function sortByOrder(input, fields = [], orders = []) {
     return input;
   }
 
-  const orderMultipliers = orders.map(getSortMultiplier);
+  const orderMultipliers = orders.map(order => (order === "desc") ? -1 : 1);
+
+  function wrap(value, index) {
+    return {
+      index,
+      value,
+      criteria: fields.map((field) => (
+        isFunction(field)
+          ? field(value)
+          : value[field]
+      ))
+    };
+  }
 
   function comparator(a, b) {
     for (let i = 0; i < a.criteria.length; i ++) {
@@ -72,27 +86,15 @@ export function sortByOrder(input, fields = [], orders = []) {
       }
     }
 
+    // preserve original order for equal a, b
     return compareValues(a.index, b.index);
   }
 
-  function wrap(value, index) {
-    return {
-      index,
-      value,
-      criteria: fields.map((field) => isFunction(field) ? field(value) : value[field])
-    };
-  }
-
-
-  // Sort a wrapped form of in the input to make Array.sort stable
+  // Sort a wrapped form of `input` to make Array.sort stable
   return input
     .map(wrap)
     .sort(comparator)
     .map(({ value }) => value);
-}
-
-function getSortMultiplier(orderName) {
-  return orderName === "desc" ? -1 : 1;
 }
 
 function compareValues(a, b) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,3 @@
-import sortByOrder from "lodash.sortbyorder";
-export { sortByOrder };
-
 function reduceToObject(inputArray, getKey, getValue) {
   const keyFunc = isFunction(getKey) ? getKey : obj => obj[getKey];
 
@@ -58,4 +55,33 @@ export function result(expr) {
   return isFunction(expr)
     ? expr()
     : expr;
+}
+
+export function sortByOrder(input, orders) {
+  function comparator(a, b) {
+    for (const [field, dir] of orders) {
+      const compared = compareValues(a[field], b[field]);
+      if(compared !== 0) {
+        return (dir === "desc")
+          ? -1 * compared
+          : compared;
+      }
+    }
+
+    return 0;
+  }
+
+  return [...input].sort(comparator);
+}
+
+function compareValues (a, b) {
+  if (isFunction(a.localeCompare)) {
+    return a.localeCompare("" + b);
+  } else if (a < b) {
+    return -1;
+  } else if (a > b) {
+    return 1;
+  } else {
+    return 0;
+  }
 }

--- a/test/unit/util-tests.js
+++ b/test/unit/util-tests.js
@@ -1,5 +1,6 @@
 import test from "tape";
-import { groupBy, indexBy, isFunction, isArray, mapObject, pickKeys, objectValues, exists, result } from "../../src/util";
+import _ from "lodash";
+import { groupBy, indexBy, isFunction, isArray, mapObject, pickKeys, objectValues, exists, result, sortByOrder } from "../../src/util";
 
 test("groupBy key name", (t) => {
   const input = [{ a: 1, b: 2 }, { a: 1, b: 3 }, { a: 2, b: 3 }, { a: 2, b: 4}];
@@ -106,5 +107,30 @@ test("result", (t) => {
   t.equal(result(1), 1);
   t.equal(result(() => "hi"), "hi");
   t.equal(result((x) => x), undefined);
+  t.end();
+});
+
+// Test against lodash's implementation
+// (ignoring un-sorted columns)
+test.only("sortByOrder", (t) => {
+  const input = [];
+  for (let a = 0; a < 3; a ++) {
+    for (let b = 0; b < 3; b ++) {
+      for (let c = 0; c < 3; c ++) {
+        for (let d = 0; d < 3; d ++) {
+          input.push({ a, b, c, d });
+        }
+      }
+    }
+  }
+
+  const fields = ["a", "b", "c", "d"];
+  const orders = ["asc"];
+  const orderSpec = _.zip(fields, orders);
+
+  const result = sortByOrder(input, orderSpec);
+  const lodashResult = _.sortByOrder(input, fields, orders);
+  t.deepEqual(result, lodashResult);
+
   t.end();
 });

--- a/test/unit/util-tests.js
+++ b/test/unit/util-tests.js
@@ -124,23 +124,17 @@ test("sortByOrder", (t) => {
     }
   }
 
-  function testOrder(spec) {
-    // Translate the sort spec for lodash
-    // [[field, dir?]] => [fields], [dirs]
-    const fields = _.pluck(spec, 0);
-    const orders = _.pluck(spec, 1).map(f => f ? f : "asc");
-
-    const result = sortByOrder(input, spec);
+  function testOrder(fields, orders) {
+    const result = sortByOrder(input, fields, orders);
     const controlResult = _.sortByOrder(input, fields, orders);
 
     t.deepEqual(result, controlResult);
   }
 
-  testOrder([["a"], ["b"], ["c"], ["d"]]);
-  testOrder([["a", "desc"], ["b", "asc"], ["c", "desc"], ["d"]]);
-  testOrder([["c", "desc"]]);
-  testOrder([["d"]]);
-  testOrder();
+  testOrder(["a", "b", "c", "d"], ["asc", "asc", "asc", "asc"]);
+  testOrder(["a", "b", "c", "d"], ["desc", "asc", "desc", "asc"]);
+  testOrder(["c"], ["desc"]);
+  testOrder(["d"], ["asc"]);
 
   t.end();
 });

--- a/test/unit/util-tests.js
+++ b/test/unit/util-tests.js
@@ -125,15 +125,19 @@ test("sortByOrder", (t) => {
   }
 
   function testOrder(spec) {
+    // Translate the sort spec for lodash
+    // [[field, dir?]] => [fields], [dirs]
     const fields = _.pluck(spec, 0);
-    const orders = _.compact(_.pluck(spec, 1));
+    const orders = _.pluck(spec, 1).map(f => f ? f : "asc");
+
     const result = sortByOrder(input, spec);
-    const controlResult = _.sortByOrder(input, spec);
+    const controlResult = _.sortByOrder(input, fields, orders);
+
     t.deepEqual(result, controlResult);
   }
 
   testOrder([["a"], ["b"], ["c"], ["d"]]);
-  testOrder([["a", "desc"], ["b"], ["c", "desc"], ["d"]]);
+  testOrder([["a", "desc"], ["b", "asc"], ["c", "desc"], ["d"]]);
   testOrder([["c", "desc"]]);
   testOrder([["d"]]);
   testOrder();

--- a/test/unit/util-tests.js
+++ b/test/unit/util-tests.js
@@ -111,7 +111,6 @@ test("result", (t) => {
 });
 
 // Test against lodash's implementation
-// (ignoring un-sorted columns)
 test("sortByOrder", (t) => {
   const input = [];
   for (let a = 0; a < 3; a ++) {
@@ -135,6 +134,7 @@ test("sortByOrder", (t) => {
   testOrder(["a", "b", "c", "d"], ["desc", "asc", "desc", "asc"]);
   testOrder(["c"], ["desc"]);
   testOrder(["d"], ["asc"]);
+  testOrder();
 
   t.end();
 });

--- a/test/unit/util-tests.js
+++ b/test/unit/util-tests.js
@@ -112,7 +112,7 @@ test("result", (t) => {
 
 // Test against lodash's implementation
 // (ignoring un-sorted columns)
-test.only("sortByOrder", (t) => {
+test("sortByOrder", (t) => {
   const input = [];
   for (let a = 0; a < 3; a ++) {
     for (let b = 0; b < 3; b ++) {
@@ -124,13 +124,19 @@ test.only("sortByOrder", (t) => {
     }
   }
 
-  const fields = ["a", "b", "c", "d"];
-  const orders = ["asc"];
-  const orderSpec = _.zip(fields, orders);
+  function testOrder(spec) {
+    const fields = _.pluck(spec, 0);
+    const orders = _.compact(_.pluck(spec, 1));
+    const result = sortByOrder(input, spec);
+    const controlResult = _.sortByOrder(input, spec);
+    t.deepEqual(result, controlResult);
+  }
 
-  const result = sortByOrder(input, orderSpec);
-  const lodashResult = _.sortByOrder(input, fields, orders);
-  t.deepEqual(result, lodashResult);
+  testOrder([["a"], ["b"], ["c"], ["d"]]);
+  testOrder([["a", "desc"], ["b"], ["c", "desc"], ["d"]]);
+  testOrder([["c", "desc"]]);
+  testOrder([["d"]]);
+  testOrder();
 
   t.end();
 });


### PR DESCRIPTION
* [x] Ready to merge

Sorting is currently from lodash `_.sortByOrder`. This PR adds a stable multi-field sort so we can remove the last runtime dependency.